### PR TITLE
chore: recommend npm-version-lens extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,7 +10,7 @@
     "miquelddg.dart-barrel-file-generator",
     "usernamehw.errorlens",
     "naumovs.color-highlight",
-    "pflannery.vscode-versionlens",
+    "legalfina.npm-version-lens",
     "flutterando.flutter-coverage",
     "ryanluker.vscode-coverage-gutters",
     "atlassian.atlascode",


### PR DESCRIPTION
## Recommend npm-version-lens

This PR updates `.vscode/extensions.json` to recommend [**npm-version-lens**](https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens) in place of the following extension(s):

- `pflannery.vscode-versionlens`

### Why?

**npm-version-lens** provides:
- Color-coded version indicators directly in `package.json`
- One-click version updates via an inline dropdown
- Inlay hints showing the latest available version

It is actively maintained and lightweight.

Marketplace: https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code extension recommendations for the development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->